### PR TITLE
Add Meeting Docs from DevOps Mutualization Meetings

### DIFF
--- a/docs/evidence-lake.md
+++ b/docs/evidence-lake.md
@@ -1,0 +1,50 @@
+## Evidence Lake
+This document has been created to capture and iterate the compliance evidence required by banking and fintech DevOps teams.
+
+## DevOps Mutualization Meeting Notes
+Date and Time : Thursday 30th July @ 1pm ET / 6pm BST - https://github.com/finos/community/issues/52#issuecomment-669343645
+
+- _Software Supply Chain with Grafeas and Kritis introduced was shown via a slide._
+- _The question was asked, "**How do we create a taxonomy around the metadata to gather a software supply chain?**"_
+- _It was explained that Grafias stores information and validity tests whilst Kritish enforces policy for the data stores in the Grafias database._
+- _It was asked whether a straw man of common pieces of metadata should be created that could include the aspects below ..._
+  - _Record of code review/4-eyes check_
+  - _Record of test execution_
+  - _Record of test result acceptance/sign off_
+  - _Record of code/image/vulnerability scanning_
+  - _Environment deployment history/promotion_
+  - _Record of ITIL related control points_
+  - _Conformance to other control points – CSO or Architecture compliance_
+  - _Code/config changes - commit id/PR/etc_
+  - _Traceability to requirements/jira issues, etc_
+  - _Test plan_
+  - _Change classification - material/minor - impact and testing scope, risk, etc_
+  - _Change/risk assessment - maybe some automated risk assessment, blast radius assessment"_
+- _The group was then asked, "**Do these common factors sound reasonable and what else can we add to the list?**"_
+- _It was agreed all points strike as necessary and certain teams like to gather evidence surrounding the changes that get added to code._
+- _It was also pointed out that change types and requirements are missing from the list._
+- _A question of the "artefact types" expected to be collected was asked and also items like "technical design documents"?_
+- _The group fed back collecting information makes a lot of sense._
+- _It was agreed that we need to collect the information, change types and audit trail related to all software changes._
+- _The group was asked, "**Is all the information actually needed as not every commit is a perfect business requirement and edge cases are difficult to track?**"_
+- _It was explained the change type does often influence how software changes move through the release pipeline._
+- _It was explained there is work being done on how to identify material change as audit trails should change to something more reliable than human, risk based, self categorisation._
+- _The approach should be more artefact related in order to reduce the risk surrounding making a change._
+- _The question "**Is there some form of automated risk assessment that improves the speed of deployment whilst reducing risk to live systems?**" was asked to the group._
+- _It was added that people want to know the blast radius of change in any given environment and architecture often influences the blast radius. Tightly coupled architectures have a greater blast radius to microservices._
+- _It was also added, items not thought through whilst coding are the areas that hit teams. Hitting deadlines with last minute changes are also the types of behaviour that increases risk of breakage._
+- _The group fed back that ticking boxes manually on change requests is a horrible way to determine success as too much paperwork with standard responses. The intent behind the change process is good, but the mechanism is wrong._
+- _The group was asked, "**Do we also need to consider what is a release and what's the difference compared to a commit?"**_
+- _It was noted the team should capture the "What" around the topics and and focus on the "How" at a later date whilst implementing the change._
+- _Group members agree the topic is close to their heart and an initial set of taxonomy is useful as we won't need to reinvent._
+- _The question "**Is there a good way to store and share the information?**" was asked to the group._
+- _A clarification of sharing artefacts or sharing policies was asked as risk and policy teams have implemented homegrown systems across 20 years to collect evidence._
+- _These teams are now moving towards industry solutions like **JIRA** and **Service Now** where attachments can be added to immutable stores._
+- _The question, "**What are the things, how are we tackling, should we share notes and get regulators involved in a more automated way?**" was asked to inform a standardised way of presenting the information across banks so regulators can understand._
+- _It was added that we should go above what the regulator wants and build a secure pipeline that reduces lead times from a security point of view as security requirements are more strict as they want demonstrable proof._
+- _The group agreed we should show the regulators what good looks like._
+- _It was explained that many silos have been removed through DevOps but there are now lots of data silos. Getting visibility across data is important to consider._
+
+## Grafeas and Kritis Reference Materials
+
+[Grafeas](https://grafeas.io) provides the metadata store with [Kritis](https://github.com/grafeas/kritis) performing the enforcement of the metadata at deploy time into Kubernetes.  For more details see the InfoQ [presentation and slides](https://www.infoq.com/presentations/supply-grafeas-kritis/). These are used within the [GCP Binary Authorisation process](https://cloud.google.com/binary-authorization/docs/overview).  An alternative (which looks similar at first glance) is [Open Policy Agent](https://www.openpolicyagent.org).

--- a/docs/self-service-glue.md
+++ b/docs/self-service-glue.md
@@ -1,0 +1,92 @@
+# How are banks orchestrating DevOps and the 'Glue' utilised to create existing self-service workflows?
+
+## Description
+
+This document has been created to gather notes regarding the 'Glue' and 'Self-Service Workflow Automation' that banking teams have produced to ensure proper controls are created and laid down to deliver software whilst adhering to internal banking policy.
+
+This document can also include the existence of internal registry integrations where projects and namespaces have a known lifecycle and association with systems, CIDB, etc. 
+
+Individual tools that are selected, automated, and orchestrated will constantly change, but the integrations between these tools and internal systems could be an interesting problem to collaborate on, or at the very least, share approaches and learnings, etc.
+
+## DevOps Mutualization Meeting Notes
+Date and Time : Thursday 30th July @ 1pm ET / 6pm BST - https://github.com/finos/community/issues/52#issuecomment-669343645
+
+- _Orchestration tools have been created but gluing them together is the interesting part. Tools out of the box also don't give metrics, so they need to be glued together to obtain._
+
+- _It was added that self service is important so things can be setup in a secure and right way by the team. Self service in cloud is important, especially considering banking is wedded to approval mechanisms and raising multiple tickets for orders._
+
+- _It was suggested an orchestration engine should be open sourced so external parties can integrate their tools. This way we reach a financial services unified voice. Open sourcing and comparing notes is a valuable conversation._
+
+- _Also, self services gives the change frequency, regulatory compliance and security needed whilst being super important_
+
+- _The group was asked, is there value having a whirlwind tour of people who represent their current pipeline orchestration over a call? The group agree there is value with many volunteers._
+
+- _The group was also asked to add vulnerability scanning tools to the discussion topic list as group representatives don't want to roll their own solutions._
+
+- _The group fed back that we might find many members are following the same principles of DevOps orchestration with some differences. If one bank leads, we can say whether we're the same or different._
+
+- _The group would like to answer the question of where we've been forced to build bespoke DevOps orchestration solutions and therefore duplicating effort._
+
+## Suggestion
+We can start by mapping the various automation tools and their main categories. For example Infrastructure as code, configuration management, Container Management (Kubernetes) and than we can describe how a potential integration between those tools may look like.
+
+## DevOps Tool Mapping Table
+
+### Resource Type Table
+Describes the type of DevOps resource to be categorised.
+| Resource Type | _Description_ |
+|:----|:----|
+| Infrastructure as Code | _Description Here_ |
+| Configuration Management | _Description Here_ |
+| Container Management (Kubernetes) | _Description Here_ |
+
+### Resource Table
+Describes the resource being utilised in banking DevOps teams.
+| Resource | _Description_ | Resource Type |
+|:----|:----|:----|
+| Name Example | _Description Example_  | Infrastructure as Code |
+| Name Example | _Description Example_  | Configuration Management |
+| Name Example | _Description Example_  | Container Management (Kubernetes) |
+
+### Resource Integration Mapping Table
+Describes resource integration, the direction of integration and how the resources are being integrated.
+| Resource Primary | Resource Secondary | Integration Direction_ | _Integration Description_ |
+|:----|:----|:----|:----|
+| Resource Name | Resource Name  | _Integration Direction Example_ | _Integration Description Example_ |
+
+## DevOps Mutualization Meeting Minutes
+**Date and Time** : Thursday 24th September @ 12:30pm ET / 5:30pm BST
+
+- **How is infrastructure provisioned against the SDLC?**
+  - Infrastructure and code deployment happening through SDLC.
+  - Terraform and other such technologies like Bit Bucket being engaged.
+- **How does a developer run a security scan before merge?** 
+  - This happens prior to pull request merge.
+  - Developers can trigger from IDEs using SonarCube, Black Duck and others
+  - Build time is a factor for being able to run security tests in realtime. Software should build fast to enable.  
+  - Dependencies are a particular problem as you can pull in multiple dependencies from external sources. 
+    - How is this reflected in build tickets and evidence stores?
+  - Getting a complete view of dependencies is ideal end state depending on the tech stack.
+  - Dependency information is obtained according to the build tools.
+  - Xray is used depending on the tech stack.
+  - Docker images are also scanned.
+  - Dependency information is also known within C++ tech stacks.
+- **Shifting left on engineering gates was a subject matter of interest that was raised by the group.** 
+- **The following items were highlighted as areas of interest for future deep dives** 
+  - **SDLC/CIM**
+  - **Group Specific Controls / Gates**
+  - **Self Service Portal**
+  - **Metrics - Collection and Reporting**
+- **Evidence store within the SDLC toolchain was selected as the deep dive by the group** 
+- **When is performance testing done?** 
+  - Project owners define the test criteria
+  - The tooling defines that criteria
+  - The testing is done as part of the release pipeline and is collected as evidence
+- **Defining what should go into an evidence store manifest will be a good aspect for mutualization**
+- **Self service portal and DevOps tools wrappers** 
+  - Is there was a terraform script for all the tools, it would be great to standardise on that.
+
+
+
+
+


### PR DESCRIPTION
## Description
This pull request consolidates notes taken from the following discussions within DevOps Mutualization into markdown documents to enable further open collaboration.

- **How are banks orchestrating DevOps and the 'Glue' utilised to create existing self-service workflows?** - https://github.com/finos/community/issues/62

- **Structuring conversations around SDLC and Iterating the different types of evidence that needs to be produced** - https://github.com/finos/community/issues/55

## Commits Included in this PR
The following commits are included in this PR

- add self service glue page e8a0160
- add evidence lake document 75c9398